### PR TITLE
B2U min/max_advanced_offset API documentation

### DIFF
--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -918,6 +918,8 @@ paths:
                       closearr: false
                       closedep: false
                       close: false
+                      min_advanced_offset: 2
+                      max_advanced_offset: 30
                     - ota_room_id: "61365"
                       ota_rate_id: rate_888
                       start_date: 2025-01-22
@@ -1047,6 +1049,21 @@ paths:
                               many cases this is equivalent to `units` = 0,
                               however it is also used to make specific rate
                               plans unavailable while leaving others bookable.
+                          min_adanced_offset:
+                            type: integer
+                            description: >
+                              Cut off restriction: Specifies the number of days
+                              before the arrival date guests are allowed to
+                              book. It is mainly used for properties that want
+                              to have a lot of advanced bookings by offering a
+                              heavily discounted rate if guests book at least an
+                              x amount of days in advance.
+                          max_advanced_offset:
+                            type: integer
+                            description: >
+                              Last Minute restriction: The number of days before
+                              the arrival date guests can book. It is mainly
+                              used to boost last-minute reservations.
                         required:
                           - ota_room_id
                           - ota_rate_id

--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -1049,7 +1049,7 @@ paths:
                               many cases this is equivalent to `units` = 0,
                               however it is also used to make specific rate
                               plans unavailable while leaving others bookable.
-                          min_adanced_offset:
+                          min_advanced_offset:
                             type: integer
                             description: >
                               Cut off restriction: Specifies the number of days

--- a/examples/methods/ARIUpdate.yaml
+++ b/examples/methods/ARIUpdate.yaml
@@ -25,6 +25,8 @@ rq:
           closearr: false
           closedep: false
           close: false
+          min_advanced_offset: 2
+          max_advanced_offset: 30
         - ota_room_id: "61365"
           ota_rate_id: "rate_888"
           start_date: "2025-01-22"

--- a/methods/ARIUpdate.yaml
+++ b/methods/ARIUpdate.yaml
@@ -125,6 +125,23 @@ post:
                           many cases this is equivalent to `units` = 0, however
                           it is also used to make specific rate plans unavailable
                           while leaving others bookable.
+                      min_adanced_offset:
+                        type: integer
+                        description: >
+                          Cut off restriction: Specifies the number of
+                          days before the arrival date guests are
+                          allowed to book. It is mainly used for
+                          properties that want to have a lot of advanced
+                          bookings by offering a heavily discounted rate
+                          if guests book at least an x amount of days in
+                          advance.
+                      max_advanced_offset:
+                        type: integer
+                        description: >
+                          Last Minute restriction: The number of days
+                          before the arrival date guests can book. It is
+                          mainly used to boost last-minute reservations.
+
                     required:
                       - ota_room_id
                       - ota_rate_id

--- a/methods/ARIUpdate.yaml
+++ b/methods/ARIUpdate.yaml
@@ -125,7 +125,7 @@ post:
                           many cases this is equivalent to `units` = 0, however
                           it is also used to make specific rate plans unavailable
                           while leaving others bookable.
-                      min_adanced_offset:
+                      min_advanced_offset:
                         type: integer
                         description: >
                           Cut off restriction: Specifies the number of


### PR DESCRIPTION
The PR adds `min_advanced_offset` and `max_advanced_offset` to the `ARIUpdate` API method doc, and to examples.