### PR TITLE
B2U min/max_advance_offset doc updates

### DIFF
--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -1051,19 +1051,25 @@ paths:
                               plans unavailable while leaving others bookable.
                           min_advanced_offset:
                             type: integer
+                            minimum: 0
                             description: >
                               Cut off restriction: Specifies the number of days
                               before the arrival date guests are allowed to
-                              book. It is mainly used for properties that want
-                              to have a lot of advanced bookings by offering a
-                              heavily discounted rate if guests book at least an
-                              x amount of days in advance.
+                              book. The value of 0 resets to no restriction,
+                              which is the default. This restirction is mainly
+                              used for properties that want to have a lot of
+                              advanced bookings by offering a heavily discounted
+                              rate if guests book at least X number of days in
+                              advance.
                           max_advanced_offset:
                             type: integer
+                            minimum: 0
                             description: >
                               Last Minute restriction: The number of days before
-                              the arrival date guests can book. It is mainly
-                              used to boost last-minute reservations.
+                              the arrival date guests can book. The value of 0
+                              resets to no restirction, which is the default.
+                              This restriction is mainly used to boost
+                              last-minute reservations.
                         required:
                           - ota_room_id
                           - ota_rate_id

--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -1056,7 +1056,7 @@ paths:
                               Cut off restriction: Specifies the number of days
                               before the arrival date guests are allowed to
                               book. The value of 0 resets to no restriction,
-                              which is the default. This restirction is mainly
+                              which is the default. This restriction is mainly
                               used for properties that want to have a lot of
                               advanced bookings by offering a heavily discounted
                               rate if guests book at least X number of days in
@@ -1067,7 +1067,7 @@ paths:
                             description: >
                               Last Minute restriction: The number of days before
                               the arrival date guests can book. The value of 0
-                              resets to no restirction, which is the default.
+                              resets to no restriction, which is the default.
                               This restriction is mainly used to boost
                               last-minute reservations.
                         required:

--- a/methods/ARIUpdate.yaml
+++ b/methods/ARIUpdate.yaml
@@ -127,20 +127,25 @@ post:
                           while leaving others bookable.
                       min_advanced_offset:
                         type: integer
+                        minimum: 0
                         description: >
                           Cut off restriction: Specifies the number of
                           days before the arrival date guests are
-                          allowed to book. It is mainly used for
+                          allowed to book.
+                          The value of 0 resets to no restriction, which is the default.
+                          This restirction is mainly used for
                           properties that want to have a lot of advanced
                           bookings by offering a heavily discounted rate
-                          if guests book at least an x amount of days in
+                          if guests book at least X number of days in
                           advance.
                       max_advanced_offset:
                         type: integer
+                        minimum: 0
                         description: >
                           Last Minute restriction: The number of days
-                          before the arrival date guests can book. It is
-                          mainly used to boost last-minute reservations.
+                          before the arrival date guests can book.
+                          The value of 0 resets to no restirction, which is the default.
+                          This restriction is mainly used to boost last-minute reservations.
 
                     required:
                       - ota_room_id

--- a/methods/ARIUpdate.yaml
+++ b/methods/ARIUpdate.yaml
@@ -133,7 +133,7 @@ post:
                           days before the arrival date guests are
                           allowed to book.
                           The value of 0 resets to no restriction, which is the default.
-                          This restirction is mainly used for
+                          This restriction is mainly used for
                           properties that want to have a lot of advanced
                           bookings by offering a heavily discounted rate
                           if guests book at least X number of days in
@@ -144,7 +144,7 @@ post:
                         description: >
                           Last Minute restriction: The number of days
                           before the arrival date guests can book.
-                          The value of 0 resets to no restirction, which is the default.
+                          The value of 0 resets to no restriction, which is the default.
                           This restriction is mainly used to boost last-minute reservations.
 
                     required:


### PR DESCRIPTION
This PR adds some more docs to min/max_advanced_offset, such as valid value >= 0, with 0 meaning no restriction. Also small changes in wording.