### PR TITLE
[CHAN-692] Document B2U OBP support

### DIFF
--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -999,23 +999,27 @@ paths:
                           num_adults_included:
                             type: integer
                             minimum: 0
-                            description: |
-                              Number of adults included in base rate
+                            description: >
+                              Number of adults included in base rate. Sent for
+                              OBP enabled channels.
                           num_children_included:
                             type: integer
                             minimum: 0
-                            description: |
-                              Number of children included in base rate
+                            description: >
+                              Number of children included in base rate. Sent for
+                              OBP enabled channels.
                           adult_N:
                             type: string
                             pattern: ^\d+(\.\d+)?$
-                            description: |
-                              Extra price for the Nth adult.
+                            description: >
+                              Extra price for the Nth adult. Sent for OBP
+                              enabled channels.
                           child_N:
                             type: string
                             pattern: ^\d+(\.\d+)?$
-                            description: |
-                              Extra price for the Nth child.
+                            description: >
+                              Extra price for the Nth child. Sent for OBP
+                              enabled channels.
                           max_los:
                             type: integer
                             minimum: 0

--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -912,7 +912,7 @@ paths:
                       end_date: 2025-02-12
                       units: 5
                       rate: "15.00"
-                      rdef_single: "2.00"
+                      rdef_single: "12.00"
                       max_los: 14
                       min_los: 2
                       closearr: false
@@ -920,6 +920,10 @@ paths:
                       close: false
                       min_advanced_offset: 2
                       max_advanced_offset: 30
+                      num_adults_included: 2
+                      num_children_included: 2
+                      adult_3: "8.00"
+                      child_3: "5.00"
                     - ota_room_id: "61365"
                       ota_rate_id: rate_888
                       start_date: 2025-01-22
@@ -992,6 +996,26 @@ paths:
                               higher than `1`. If the value is `0` we recommend
                               to not make the single use rate available, or to
                               just use the same price as for `rate`.
+                          num_adults_included:
+                            type: integer
+                            minimum: 0
+                            description: |
+                              Number of adults included in base rate
+                          num_children_included:
+                            type: integer
+                            minimum: 0
+                            description: |
+                              Number of children included in base rate
+                          adult_N:
+                            type: string
+                            pattern: ^\d+(\.\d+)?$
+                            description: |
+                              Extra price for the Nth adult.
+                          child_N:
+                            type: string
+                            pattern: ^\d+(\.\d+)?$
+                            description: |
+                              Extra price for the Nth child.
                           max_los:
                             type: integer
                             minimum: 0

--- a/examples/methods/ARIUpdate.yaml
+++ b/examples/methods/ARIUpdate.yaml
@@ -19,7 +19,7 @@ rq:
           end_date: "2025-02-12"
           units: 5
           rate: "15.00"
-          rdef_single: "2.00"
+          rdef_single: "12.00"
           max_los: 14
           min_los: 2
           closearr: false
@@ -27,6 +27,10 @@ rq:
           close: false
           min_advanced_offset: 2
           max_advanced_offset: 30
+          num_adults_included: 2
+          num_children_included: 2
+          adult_3: "8.00"
+          child_3: "5.00"
         - ota_room_id: "61365"
           ota_rate_id: "rate_888"
           start_date: "2025-01-22"

--- a/methods/ARIUpdate.yaml
+++ b/methods/ARIUpdate.yaml
@@ -81,6 +81,26 @@ post:
                           the value is `0` we recommend to not make the single
                           use rate available, or to just use the same price as
                           for `rate`.
+                      num_adults_included:
+                        type: integer
+                        minimum: 0
+                        description: >
+                          Number of adults included in base rate
+                      num_children_included:
+                        type: integer
+                        minimum: 0
+                        description: >
+                          Number of children included in base rate
+                      adult_N:
+                        type: string
+                        pattern: '^\d+(\.\d+)?$'
+                        description: >
+                          Extra price for the Nth adult.
+                      child_N:
+                        type: string
+                        pattern: '^\d+(\.\d+)?$'
+                        description: >
+                          Extra price for the Nth child.
                       max_los:
                         type: integer
                         minimum: 0

--- a/methods/ARIUpdate.yaml
+++ b/methods/ARIUpdate.yaml
@@ -85,22 +85,22 @@ post:
                         type: integer
                         minimum: 0
                         description: >
-                          Number of adults included in base rate
+                          Number of adults included in base rate. Sent for OBP enabled channels.
                       num_children_included:
                         type: integer
                         minimum: 0
                         description: >
-                          Number of children included in base rate
+                          Number of children included in base rate. Sent for OBP enabled channels.
                       adult_N:
                         type: string
                         pattern: '^\d+(\.\d+)?$'
                         description: >
-                          Extra price for the Nth adult.
+                          Extra price for the Nth adult. Sent for OBP enabled channels.
                       child_N:
                         type: string
                         pattern: '^\d+(\.\d+)?$'
                         description: >
-                          Extra price for the Nth child.
+                          Extra price for the Nth child. Sent for OBP enabled channels.
                       max_los:
                         type: integer
                         minimum: 0


### PR DESCRIPTION
This PR adds OBP support docs to ARIUpdate. The new ARIUpdate params added for OBP support are:
```
num_adults_included
num_children_included
adult_N
child_N
```