### PR TITLE
MYAL-8116 DeleteRatePlan UpdateRatePlan API methods

### DIFF
--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -2980,7 +2980,7 @@ paths:
     post:
       operationId: delete_rateplan
       description: |
-        Delete rateplan after it has been deleted on myallocator.
+        Delete rateplan after it has been deleted on Cloudbeds.
       requestBody:
         content:
           application/json:
@@ -3011,7 +3011,7 @@ paths:
                         mya_rateplan_id:
                           type: integer
                           minimum: 1
-                          description: Rate plan ID on myallocator
+                          description: Cloudbeds rate plan ID.
                       required:
                         - mya_rateplan_id
                     verb:
@@ -3047,7 +3047,7 @@ paths:
     post:
       operationId: update_rateplan
       description: |
-        Create of update rate plan after it has been changed on myallocator.
+        Create of update rate plan after it has been changed on Cloudbeds.
       requestBody:
         content:
           application/json:
@@ -3087,7 +3087,7 @@ paths:
                         mya_rateplan_id:
                           type: integer
                           minimum: 1
-                          description: Rate plan ID on myallocator.
+                          description: Cloudbeds rate plan ID.
                         ota_rateplan_id:
                           type: string
                           description: Channel rate plan ID.

--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -2976,6 +2976,226 @@ paths:
                   a"
           description: UpdateTaxes
       summary: UpdateTaxes
+  /DeleteRatePlan:
+    post:
+      operationId: delete_rateplan
+      description: |
+        Delete rateplan after it has been deleted on myallocator.
+      requestBody:
+        content:
+          application/json:
+            examples:
+              DeleteRatePlan:
+                summary: DeleteRatePlan
+                value:
+                  verb: DeleteRatePlan
+                  ota_property_id: lake_view_hotel
+                  ota_property_password: very-secret-password
+                  ota_property_sub_id: "10034818"
+                  mya_property_id: 25678
+                  guid: 6C08B96E-450D-4E6A-9933-7D0305730305
+                  shared_secret: s3cr3ts4uc3
+                  ota_cid: ota
+                  rateplan:
+                    mya_rateplan_id: 115326
+            schema:
+              allOf:
+                - $ref: "#/paths/~1GetRoomTypes/post/requestBody/content/application~1json/schema\
+                    /allOf/0"
+                - type: object
+                  properties:
+                    rateplan:
+                      type: object
+                      description: Rate plan to delete
+                      properties:
+                        mya_rateplan_id:
+                          type: integer
+                          minimum: 1
+                          description: Rate plan ID on myallocator
+                      required:
+                        - mya_rateplan_id
+                    verb:
+                      type: string
+                      enum:
+                        - DeleteRatePlan
+                  required:
+                    - rateplan
+                    - verb
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                Success:
+                  summary: Success
+                  value:
+                    success: true
+                Failure:
+                  summary: Invalid credentials sent
+                  value:
+                    success: false
+                    errors:
+                      - id: 1001
+                        msg: The login details you provided are incorrect.
+              schema:
+                $ref: "#/paths/~1HealthCheck/post/responses/200/content/application~1json/schem\
+                  a"
+          description: DeleteRatePlan
+      summary: DeleteRatePlan
+  /UpdateRatePlan:
+    post:
+      operationId: update_rateplan
+      description: |
+        Create of update rate plan after it has been changed on myallocator.
+      requestBody:
+        content:
+          application/json:
+            examples:
+              UpdateRatePlan:
+                summary: UpdateRateplan
+                value:
+                  verb: UpdateRatePlan
+                  ota_property_id: lake_view_hotel
+                  ota_property_password: very-secret-password
+                  ota_property_sub_id: "10034818"
+                  mya_property_id: 25678
+                  guid: 6C08B96E-450D-4E6A-9933-7D0305730305
+                  shared_secret: s3cr3ts4uc3
+                  ota_cid: ota
+                  rateplan:
+                    mya_rateplan_id: 115629
+                    label_private: NR
+                    label_public: Non-refundable
+                    max_advanced_offset: 90
+                    max_occupancy: 3
+                    max_stay: 14
+                    min_advanced_offset: 0
+                    min_occupancy: 1
+                    min_stay: 1
+                    smart_policy_id: 345673
+                    meal_codes:
+                      - 1
+                      - 19
+                      - 21
+                      - 22
+                    ota_rateplan_id: "3456"
+            schema:
+              allOf:
+                - $ref: "#/paths/~1GetRoomTypes/post/requestBody/content/application~1json/schema\
+                    /allOf/0"
+                - type: object
+                  properties:
+                    rateplan:
+                      type: object
+                      properties:
+                        mya_rateplan_id:
+                          type: integer
+                          minimum: 1
+                          description: Rate plan ID on myallocator.
+                        ota_rateplan_id:
+                          type: string
+                          description: Channel rate plan ID.
+                        label_private:
+                          type: string
+                          description: The private name of the rate plan, only shown to the property.
+                        label_public:
+                          type: string
+                          description: The public name of the rate plan, that can also be shown to
+                            customers.
+                        mya_room_id:
+                          type: integer
+                          minimum: 1
+                          description: Room ID on myallocator this pate plan is applied to
+                        ota_room_id:
+                          type: string
+                        max_advanced_offset:
+                          type: integer
+                          minimum: 0
+                          description: >
+                            "Last Minute restriction: The number of days before
+                            the arrival date guests can book. The value of 0
+                            resets to no restriction, which is the default. This
+                            restriction is mainly used to boost last-minute
+                            reservations."
+                        max_occupancy:
+                          type: integer
+                          minimum: 0
+                          description: Maximum occupancy, `0` if there are no restrictions.
+                        max_stay:
+                          type: integer
+                          minimum: 0
+                          description: >
+                            Default maximum length of stay, `0` for no limit.
+                            Needs to be >= `min_stay` (unless it's 0).
+                        min_advanced_offset:
+                          type: integer
+                          minimum: 0
+                          description: >
+                            "Cut off restriction: Specifies the number of days
+                            before the arrival date guests are allowed to book.
+                            The value of 0 resets to no restriction, which is
+                            the default. This restriction is mainly used for
+                            properties that want to have a lot of advanced
+                            bookings by offering a heavily discounted rate if
+                            guests book at least X number of days in advance."
+                        min_occupancy:
+                          type: integer
+                          minimum: 0
+                          description: Minimum occupancy, `0` if there are no restrictions.
+                        min_stay:
+                          type: integer
+                          minimum: 0
+                          description: >
+                            Default minimum length of stay, `0` for no limit.
+                            Needs to be <= `max_stay`.
+                        smart_policy_id:
+                          type: integer
+                          minimum: 1
+                          description: The ID of the Smart Policy assigned to this rate plan.
+                        meal_codes:
+                          type: array
+                          description: >
+                            List of meal codes that are available for this rate
+                            plan. OTA meal code. `1` - all inclusive, `2` -
+                            american/full board, `3` - bed & breakfast etc.
+                          items:
+                            type: integer
+                            minimum: 1
+                            maximum: 24
+                      required:
+                        - mya_rateplan_id
+                        - label_public
+                        - label_private
+                    verb:
+                      type: string
+                      enum:
+                        - UpdateRatePlan
+                  required:
+                    - rateplan
+                    - verb
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                Success:
+                  summary: Success
+                  value:
+                    success: true
+                Failure:
+                  summary: Invalid credentials
+                  value:
+                    success: false
+                    errors:
+                      - id: 1001
+                        msg: The login details you provided are incorrect
+              schema:
+                $ref: "#/paths/~1HealthCheck/post/responses/200/content/application~1json/schem\
+                  a"
+          description: UpdateRatePlan
+      summary: UpdateRatePlan
   /ARIFullRefresh:
     post:
       operationId: ari_full_refresh

--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -3067,13 +3067,8 @@ paths:
                     mya_rateplan_id: 115629
                     label_private: NR
                     label_public: Non-refundable
-                    max_advanced_offset: 90
                     max_occupancy: 3
-                    max_stay: 14
-                    min_advanced_offset: 0
                     min_occupancy: 1
-                    min_stay: 1
-                    smart_policy_id: 345673
                     meal_codes:
                       - 1
                       - 19
@@ -3103,56 +3098,14 @@ paths:
                           type: string
                           description: The public name of the rate plan, that can also be shown to
                             customers.
-                        mya_room_id:
-                          type: integer
-                          minimum: 1
-                          description: Room ID on myallocator this pate plan is applied to
-                        ota_room_id:
-                          type: string
-                        max_advanced_offset:
-                          type: integer
-                          minimum: 0
-                          description: >
-                            "Last Minute restriction: The number of days before
-                            the arrival date guests can book. The value of 0
-                            resets to no restriction, which is the default. This
-                            restriction is mainly used to boost last-minute
-                            reservations."
                         max_occupancy:
                           type: integer
                           minimum: 0
-                          description: Maximum occupancy, `0` if there are no restrictions.
-                        max_stay:
-                          type: integer
-                          minimum: 0
-                          description: >
-                            Default maximum length of stay, `0` for no limit.
-                            Needs to be >= `min_stay` (unless it's 0).
-                        min_advanced_offset:
-                          type: integer
-                          minimum: 0
-                          description: >
-                            "Cut off restriction: Specifies the number of days
-                            before the arrival date guests are allowed to book.
-                            The value of 0 resets to no restriction, which is
-                            the default. This restriction is mainly used for
-                            properties that want to have a lot of advanced
-                            bookings by offering a heavily discounted rate if
-                            guests book at least X number of days in advance."
+                          description: Maximum occupancy, `0` means no restrictions.
                         min_occupancy:
                           type: integer
                           minimum: 0
-                          description: Minimum occupancy, `0` if there are no restrictions.
-                        min_stay:
-                          type: integer
-                          minimum: 0
-                          description: >
-                            Default minimum length of stay, `0` for no limit.
-                            Needs to be <= `max_stay`.
-                        smart_policy_id:
-                          type: integer
-                          minimum: 1
-                          description: The ID of the Smart Policy assigned to this rate plan.
+                          description: Minimum occupancy, `0` means no restrictions.
                         meal_codes:
                           type: array
                           description: >

--- a/b2u.yaml
+++ b/b2u.yaml
@@ -164,6 +164,10 @@ paths:
     $ref: methods/GetSubProperties.yaml
   /UpdateTaxes:
     $ref: methods/UpdateTaxes.yaml
+  /DeleteRatePlan:
+    $ref: methods/DeleteRatePlan.yaml
+  /UpdateRatePlan:
+    $ref: methods/UpdateRatePlan.yaml
 
   /ARIFullRefresh:
     $ref: methods/ARIFullRefresh.yaml

--- a/examples/methods/DeleteRatePlan.yaml
+++ b/examples/methods/DeleteRatePlan.yaml
@@ -1,0 +1,27 @@
+---
+rq:
+  DeleteRatePlan:
+    summary: DeleteRatePlan
+    value:
+      verb: DeleteRatePlan
+      ota_property_id: lake_view_hotel
+      ota_property_password: very-secret-password
+      ota_property_sub_id: '10034818'
+      mya_property_id: 25678
+      guid: 6C08B96E-450D-4E6A-9933-7D0305730305
+      shared_secret: s3cr3ts4uc3
+      ota_cid: ota
+      rateplan:
+        mya_rate_id: 115326
+rs:
+  Success:
+    summary: Success
+    value:
+      success: true
+  Failure:
+    summary: Invalid credentials sent
+    value:
+      success: false
+      errors:
+        - id: 1001
+          msg: The login details you provided are incorrect.

--- a/examples/methods/DeleteRatePlan.yaml
+++ b/examples/methods/DeleteRatePlan.yaml
@@ -12,7 +12,7 @@ rq:
       shared_secret: s3cr3ts4uc3
       ota_cid: ota
       rateplan:
-        mya_rate_id: 115326
+        mya_rateplan_id: 115326
 rs:
   Success:
     summary: Success

--- a/examples/methods/UpdateRatePlan.yaml
+++ b/examples/methods/UpdateRatePlan.yaml
@@ -15,13 +15,8 @@ rq:
         mya_rateplan_id: 115629
         label_private: NR
         label_public: Non-refundable
-        max_advanced_offset: 90
         max_occupancy: 3
-        max_stay: 14
-        min_advanced_offset: 0
         min_occupancy: 1
-        min_stay: 1
-        smart_policy_id: 345673
         meal_codes:
           - 1
           - 19

--- a/examples/methods/UpdateRatePlan.yaml
+++ b/examples/methods/UpdateRatePlan.yaml
@@ -1,0 +1,42 @@
+---
+rq:
+  UpdateRatePlan:
+    summary: UpdateRateplan
+    value:
+      verb: UpdateRatePlan
+      ota_property_id: lake_view_hotel
+      ota_property_password: very-secret-password
+      ota_property_sub_id: '10034818'
+      mya_property_id: 25678
+      guid: 6C08B96E-450D-4E6A-9933-7D0305730305
+      shared_secret : s3cr3ts4uc3
+      ota_cid: ota
+      rateplan:
+        mya_rate_id: 115629
+        label_private: NR
+        label_public: Non-refundable
+        max_advanced_offset: 90
+        max_occupancy: 3
+        max_stay: 14
+        min_advanced_offset: 0
+        min_occupancy: 1
+        min_stay: 1
+        smart_policy_id: 345673
+        meal_codes:
+          - 1
+          - 19
+          - 21
+          - 22
+        ota_rate_id: 3456
+rs:
+  Success:
+    summary: Success
+    value:
+      success: true
+  Failure:
+    summary: Invalid credentials
+    value:
+      success: false
+      errors:
+        - id: 1001
+          msg: The login details you provided are incorrect

--- a/examples/methods/UpdateRatePlan.yaml
+++ b/examples/methods/UpdateRatePlan.yaml
@@ -12,7 +12,7 @@ rq:
       shared_secret : s3cr3ts4uc3
       ota_cid: ota
       rateplan:
-        mya_rate_id: 115629
+        mya_rateplan_id: 115629
         label_private: NR
         label_public: Non-refundable
         max_advanced_offset: 90
@@ -27,7 +27,7 @@ rq:
           - 19
           - 21
           - 22
-        ota_rate_id: 3456
+        ota_rateplan_id: "3456"
 rs:
   Success:
     summary: Success

--- a/methods/DeleteRatePlan.yaml
+++ b/methods/DeleteRatePlan.yaml
@@ -2,7 +2,7 @@
 post:
   operationId: delete_rateplan
   description: >
-    Delete rateplan after it has been deleted on myallocator.
+    Delete rateplan after it has been deleted on Cloudbeds.
   requestBody:
     content:
       application/json:
@@ -20,7 +20,7 @@ post:
                     mya_rateplan_id:
                       type: integer
                       minimum: 1
-                      description: Rate plan ID on myallocator
+                      description: Cloudbeds rate plan ID.
                   required:
                     - mya_rateplan_id
                 verb:

--- a/methods/DeleteRatePlan.yaml
+++ b/methods/DeleteRatePlan.yaml
@@ -1,0 +1,43 @@
+---
+post:
+  operationId: delete_rateplan
+  description: >
+    Delete rateplan after it has been deleted on myallocator.
+  requestBody:
+    content:
+      application/json:
+        examples:
+          $ref: ../examples/methods/DeleteRatePlan.yaml#/rq
+        schema:
+          allOf:
+            - $ref: ../schemas.yaml#/auth
+            - type: object
+              properties:
+                rateplan:
+                  type: object
+                  description: Rate plan to delete
+                  properties:
+                    mya_rateplan_id:
+                      type: integer
+                      minimum: 1
+                      description: Rate plan ID on myallocator
+                  required:
+                    - mya_rateplan_id
+                verb:
+                  type: string
+                  enum:
+                    - DeleteRatePlan
+              required:
+                - rateplan
+                - verb
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          examples:
+            $ref: ../examples/methods/DeleteRatePlan.yaml#/rs
+          schema:
+            $ref: ../schemas.d/response_simple.yaml
+      description: DeleteRatePlan
+  summary: DeleteRatePlan

--- a/methods/UpdateRatePlan.yaml
+++ b/methods/UpdateRatePlan.yaml
@@ -16,11 +16,11 @@ post:
                 rateplan:
                   type: object
                   properties:
-                    mya_rate_id:
+                    mya_rateplan_id:
                       type: integer
                       minimum: 1
                       description: Rate plan ID on myallocator.
-                    ota_rate_id:
+                    ota_rateplan_id:
                       type: string
                       description: Channel rate plan ID.
                     label_private:
@@ -29,6 +29,12 @@ post:
                     label_public:
                       type: string
                       description: The public name of the rate plan, that can also be shown to customers.
+                    mya_room_id:
+                      type: integer
+                      minimum: 1
+                      description: Room ID on myallocator this pate plan is applied to
+                    ota_room_id:
+                      type: string
                     max_advanced_offset:
                       type: integer
                       minimum: 0
@@ -69,15 +75,15 @@ post:
                       description: The ID of the Smart Policy assigned to this rate plan.
                     meal_codes:
                       type: array
-                      description: List of meal codes that are available for this rate plan.
-                        items:
-                          type: integer
-                          minimum: 1
-                          maximum: 24
-                          description: >
-                            OTA meal code. `1` - all inclusive, `2` - american/full board, `3` - bed & breakfast etc.
+                      description: >
+                        List of meal codes that are available for this rate plan.
+                        OTA meal code. `1` - all inclusive, `2` - american/full board, `3` - bed & breakfast etc.
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 24
                   required:
-                    - mya_rate_id
+                    - mya_rateplan_id
                     - label_public
                     - label_private
                 verb:

--- a/methods/UpdateRatePlan.yaml
+++ b/methods/UpdateRatePlan.yaml
@@ -29,50 +29,14 @@ post:
                     label_public:
                       type: string
                       description: The public name of the rate plan, that can also be shown to customers.
-                    mya_room_id:
-                      type: integer
-                      minimum: 1
-                      description: Room ID on myallocator this pate plan is applied to
-                    ota_room_id:
-                      type: string
-                    max_advanced_offset:
-                      type: integer
-                      minimum: 0
-                      description: >
-                        "Last Minute restriction: The number of days before the arrival date guests can book.
-                        The value of 0 resets to no restriction, which is the default. This restriction is
-                        mainly used to boost last-minute reservations."
                     max_occupancy:
                       type: integer
                       minimum: 0
-                      description: Maximum occupancy, `0` if there are no restrictions.
-                    max_stay:
-                      type: integer
-                      minimum: 0
-                      description: >
-                        Default maximum length of stay, `0` for no limit. Needs to be >= `min_stay` (unless it's 0).
-                    min_advanced_offset:
-                      type: integer
-                      minimum: 0
-                      description: >
-                        "Cut off restriction: Specifies the number of days before the arrival date guests
-                        are allowed to book. The value of 0 resets to no restriction, which is the default.
-                        This restriction is mainly used for properties that want to have a lot of advanced
-                        bookings by offering a heavily discounted rate if guests book at least X number of
-                        days in advance."
+                      description: Maximum occupancy, `0` means no restrictions.
                     min_occupancy:
                       type: integer
                       minimum: 0
-                      description: Minimum occupancy, `0` if there are no restrictions.
-                    min_stay:
-                      type: integer
-                      minimum: 0
-                      description: >
-                        Default minimum length of stay, `0` for no limit. Needs to be <= `max_stay`.
-                    smart_policy_id:
-                      type: integer
-                      minimum: 1
-                      description: The ID of the Smart Policy assigned to this rate plan.
+                      description: Minimum occupancy, `0` means no restrictions.
                     meal_codes:
                       type: array
                       description: >

--- a/methods/UpdateRatePlan.yaml
+++ b/methods/UpdateRatePlan.yaml
@@ -2,7 +2,7 @@
 post:
   operationId: update_rateplan
   description: >
-    Create of update rate plan after it has been changed on myallocator.
+    Create of update rate plan after it has been changed on Cloudbeds.
   requestBody:
     content:
       application/json:
@@ -19,7 +19,7 @@ post:
                     mya_rateplan_id:
                       type: integer
                       minimum: 1
-                      description: Rate plan ID on myallocator.
+                      description: Cloudbeds rate plan ID.
                     ota_rateplan_id:
                       type: string
                       description: Channel rate plan ID.

--- a/methods/UpdateRatePlan.yaml
+++ b/methods/UpdateRatePlan.yaml
@@ -1,0 +1,100 @@
+---
+post:
+  operationId: update_rateplan
+  description: >
+    Create of update rate plan after it has been changed on myallocator.
+  requestBody:
+    content:
+      application/json:
+        examples:
+          $ref: ../examples/methods/UpdateRatePlan.yaml#/rq
+        schema:
+          allOf:
+            - $ref: ../schemas.yaml#/auth
+            - type: object
+              properties:
+                rateplan:
+                  type: object
+                  properties:
+                    mya_rate_id:
+                      type: integer
+                      minimum: 1
+                      description: Rate plan ID on myallocator.
+                    ota_rate_id:
+                      type: string
+                      description: Channel rate plan ID.
+                    label_private:
+                      type: string
+                      description: The private name of the rate plan, only shown to the property.
+                    label_public:
+                      type: string
+                      description: The public name of the rate plan, that can also be shown to customers.
+                    max_advanced_offset:
+                      type: integer
+                      minimum: 0
+                      description: >
+                        "Last Minute restriction: The number of days before the arrival date guests can book.
+                        The value of 0 resets to no restriction, which is the default. This restriction is
+                        mainly used to boost last-minute reservations."
+                    max_occupancy:
+                      type: integer
+                      minimum: 0
+                      description: Maximum occupancy, `0` if there are no restrictions.
+                    max_stay:
+                      type: integer
+                      minimum: 0
+                      description: >
+                        Default maximum length of stay, `0` for no limit. Needs to be >= `min_stay` (unless it's 0).
+                    min_advanced_offset:
+                      type: integer
+                      minimum: 0
+                      description: >
+                        "Cut off restriction: Specifies the number of days before the arrival date guests
+                        are allowed to book. The value of 0 resets to no restriction, which is the default.
+                        This restriction is mainly used for properties that want to have a lot of advanced
+                        bookings by offering a heavily discounted rate if guests book at least X number of
+                        days in advance."
+                    min_occupancy:
+                      type: integer
+                      minimum: 0
+                      description: Minimum occupancy, `0` if there are no restrictions.
+                    min_stay:
+                      type: integer
+                      minimum: 0
+                      description: >
+                        Default minimum length of stay, `0` for no limit. Needs to be <= `max_stay`.
+                    smart_policy_id:
+                      type: integer
+                      minimum: 1
+                      description: The ID of the Smart Policy assigned to this rate plan.
+                    meal_codes:
+                      type: array
+                      description: List of meal codes that are available for this rate plan.
+                        items:
+                          type: integer
+                          minimum: 1
+                          maximum: 24
+                          description: >
+                            OTA meal code. `1` - all inclusive, `2` - american/full board, `3` - bed & breakfast etc.
+                  required:
+                    - mya_rate_id
+                    - label_public
+                    - label_private
+                verb:
+                  type: string
+                  enum:
+                    - UpdateRatePlan
+              required:
+                - rateplan
+                - verb
+    required: true
+  responses:
+    "200":
+      content:
+        application/json:
+          examples:
+            $ref: ../examples/methods/UpdateRatePlan.yaml#/rs
+          schema:
+            $ref: ../schemas.d/response_simple.yaml
+      description: UpdateRatePlan
+  summary: UpdateRatePlan


### PR DESCRIPTION
![Screenshot from 2024-06-17 12-24-34](https://github.com/MyAllocator/build2us-apidocs/assets/114253347/05aad7bc-1ad7-4be9-8c7f-dc13dbde8e19)
We send only rate plan data that are not sent by ARIUpdate. Ie we don't send `min_los`, `max_advanced_offset`, etc
