### PR TITLE
Remove "description" from taxes

### DIFF
--- a/b2u-combined.yaml
+++ b/b2u-combined.yaml
@@ -1376,7 +1376,6 @@ paths:
                         calculation_basis: rate
                         category: vat
                         code: IVA
-                        description: Impuesto
                         id: 4761
                         is_fee: false
                         is_inclusive: true
@@ -2866,7 +2865,6 @@ paths:
                         calculation_basis: rate
                         category: vat
                         code: IVA
-                        description: Impuesto
                         id: 4761
                         is_fee: false
                         is_inclusive: true
@@ -2879,7 +2877,6 @@ paths:
                       - amount: 5
                         applies_per: pet
                         category: other_fee
-                        description: Pet fee applies for each pet when total number of pets is more than one.
                         id: 4762
                         is_fee: true
                         is_inclusive: false
@@ -2895,7 +2892,6 @@ paths:
                         applies_per: adult
                         calculation_basis: rate
                         category: tourism_tax
-                        description: Per person per night when number of nights are greater than 2
                         id: 4763
                         is_fee: false
                         is_inclusive: false
@@ -2941,7 +2937,6 @@ paths:
                         applies_per: booking
                         calculation_basis: rate
                         category: other_fee
-                        description: Weekend service fee
                         id: 4765
                         is_fee: true
                         is_inclusive: false
@@ -5059,9 +5054,6 @@ components:
           type: string
           description: |
             Optional custom field to store an external system ID. Not guaranteed to be unique.
-        description:
-          type: string
-          description: Tax/fee description.
         name:
           type: string
           description: Tax/fee name.

--- a/examples/methods/CreateProperty.yaml
+++ b/examples/methods/CreateProperty.yaml
@@ -33,7 +33,6 @@ rq:
           calculation_basis: rate
           category: vat
           code: IVA
-          description: Impuesto
           id: 4761
           is_fee: false
           is_inclusive: true

--- a/examples/methods/UpdateTaxes.yaml
+++ b/examples/methods/UpdateTaxes.yaml
@@ -18,7 +18,6 @@ rq:
             calculation_basis: rate
             category: vat
             code: IVA
-            description: Impuesto
             id: 4761
             is_fee: false
             is_inclusive: true
@@ -31,7 +30,6 @@ rq:
           - amount: 5
             applies_per: pet
             category: other_fee
-            description: Pet fee applies for each pet when total number of pets is more than one.
             id: 4762
             is_fee: true
             is_inclusive: false
@@ -47,7 +45,6 @@ rq:
             applies_per: adult
             calculation_basis: rate
             category: tourism_tax
-            description: Per person per night when number of nights are greater than 2
             id: 4763
             is_fee: false
             is_inclusive: false
@@ -93,7 +90,6 @@ rq:
             applies_per: booking
             calculation_basis: rate
             category: other_fee
-            description: Weekend service fee
             id: 4765
             is_fee: true
             is_inclusive: false

--- a/examples/taxes.yaml
+++ b/examples/taxes.yaml
@@ -4,7 +4,6 @@
   calculation_basis: rate
   category: vat
   code: IVA
-  description: Impuesto
   id: 4761
   is_fee: false
   is_inclusive: true
@@ -17,7 +16,6 @@
 - amount: 5
   applies_per: pet
   category: other_fee
-  description: Pet fee applies for each pet when total number of pets is more than one.
   id: 4762
   is_fee: true
   is_inclusive: false
@@ -33,7 +31,6 @@
   applies_per: adult
   calculation_basis: rate
   category: tourism_tax
-  description: Per person per night when number of nights are greater than 2
   id: 4763
   is_fee: false
   is_inclusive: false
@@ -79,7 +76,6 @@
   applies_per: booking
   calculation_basis: rate
   category: other_fee
-  description: Weekend service fee
   id: 4765
   is_fee: true
   is_inclusive: false

--- a/schemas.d/tax_info.yaml
+++ b/schemas.d/tax_info.yaml
@@ -64,9 +64,6 @@ properties:
     type: string
     description: >
       Optional custom field to store an external system ID. Not guaranteed to be unique.
-  description:
-    type: string
-    description: Tax/fee description.
   name:
     type: string
     description: Tax/fee name.


### PR DESCRIPTION
There is no tax description in MFD UI, so we always have it empty. Channel asked about it in MYAL-8808.